### PR TITLE
feat(tag): Add `SvgBlock` enum for HTML SVG tag representation and implement `BlockInterface` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0 Under development
 
 - Enh #4: Refactor codebase to improve performance (@terabytesoftw)
+- Enh #5: Add `SvgBlock` enum for HTML SVG tag representation and implement `BlockInterface` class.
 
 ## 0.2.0 March 31, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-libxml": "*",
         "enshrined/svg-sanitize": "^0.22",
         "ui-awesome/html-attribute": "^0.4",
-        "ui-awesome/html-core": "^0.4",
+        "ui-awesome/html-core": "0.5.x-dev",
         "ui-awesome/html-helper": "^0.6"
     },
     "require-dev": {

--- a/src/Base/BaseSvg.php
+++ b/src/Base/BaseSvg.php
@@ -40,8 +40,8 @@ use function is_string;
  * - Supports extensibility for custom SVG element implementations.
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
- * @see BaseBlock for the base block-level implementation.
- * @see SvgProperty for supported SVG attributes.
+ * {@see BaseBlock} for the base block-level implementation.
+ * {@see SvgProperty} for supported SVG attributes.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -106,6 +106,11 @@ abstract class BaseSvg extends BaseBlock implements Stringable
      *
      * This ensures 'title' is never rendered as a standard SVG attribute, without modifying the internal state of the
      * object.
+     *
+     * Usage example:
+     * ```php
+     * $svg->getAttributes();
+     * ```
      */
     public function getAttributes(): array
     {
@@ -123,6 +128,11 @@ abstract class BaseSvg extends BaseBlock implements Stringable
      * element and prepends it to the content, ensuring proper accessibility for manually constructed SVGs.
      *
      * @return string Combined content string with the title injected.
+     *
+     * Usage example:
+     * ```php
+     * $svg->getContent();
+     * ```
      */
     public function getContent(): string
     {
@@ -472,7 +482,7 @@ abstract class BaseSvg extends BaseBlock implements Stringable
 
         $svg->loadXML($cleanedSvg, LIBXML_NOBLANKS);
 
-        return $svg->getElementsByTagName($this->getTag()->value)->item(0);
+        return $svg->getElementsByTagName((string) $this->getTag()->value)->item(0);
     }
 
     /**

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Svg;
 
-use UIAwesome\Html\Core\Tag\Block;
+use UIAwesome\Html\Core\Tag\BlockInterface;
+use UIAwesome\Html\Svg\Tag\SvgBlock;
 
 /**
  * SVG `<svg>` element implementation for scalable vector graphics containers.
@@ -25,7 +26,6 @@ use UIAwesome\Html\Core\Tag\Block;
  * coordinate system and viewport for SVG graphics. It is used as the outermost element of SVG documents, or to embed
  * SVG fragments within HTML or SVG documents.
  * {@see BaseSvg} for the base implementation.
- * {@see Block} for valid block-level tags.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -35,10 +35,12 @@ final class Svg extends Base\BaseSvg
     /**
      * Returns the tag enumeration for the `<svg>` element.
      *
-     * @return Block Tag enumeration instance for `<svg>`.
+     * @return BlockInterface Tag enumeration instance for `<svg>`.
+     *
+     * {@see SvgBlock} for valid SVG block-level tags.
      */
-    protected function getTag(): Block
+    protected function getTag(): BlockInterface
     {
-        return Block::SVG;
+        return SvgBlock::SVG;
     }
 }

--- a/src/Tag/SvgBlock.php
+++ b/src/Tag/SvgBlock.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tag;
+
+use UIAwesome\Html\Core\Tag\BlockInterface;
+
+/**
+ * Represents standardized SVG block-level HTML element names as enum cases.
+ *
+ * Provides a type-safe set of SVG element tokens and concise documentation aligned with the MDN reference.
+ *
+ * Key features:
+ * - Designed for use in helpers and components that need an explicit SVG element name.
+ * - Implementation of {@see BlockInterface} for contract adherence.
+ * - Suitable for building SVG markup and element validation.
+ * - Values follow the SVG elements listed in the MDN documentation.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element
+ * {@see BlockInterface} for contract details.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum SvgBlock: string implements BlockInterface
+{
+    /**
+     * `<svg>` - The root container for SVG graphics.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
+     */
+    case SVG = 'svg';
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `SvgBlock` enumeration for HTML SVG tag representation with enhanced type-safety.

* **Chores**
  * Updated dependency version for ui-awesome/html-core to 0.5.x-dev.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->