### PR TITLE
feat(attribute): Add `HasStroke` trait and corresponding tests for managing SVG `stroke` attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #7: Add `BaseSvgTag` and `Defs` classes for SVG block-level elements and related tests (@terabytesoftw)
 - Enh #8: Add `HasFill` trait and corresponding tests for managing SVG `fill` attribute (@terabytesoftw)
 - Bug #9: Correct SVG specification reference in `HasFill` trait documentation (@terabytesoftw)
+- Enh #10: Add `HasStroke` trait and corresponding tests for managing SVG `stroke` attribute (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasStroke.php
+++ b/src/Attribute/HasStroke.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Attribute;
+
+use UIAwesome\Html\Svg\Values\SvgProperty;
+
+/**
+ * Trait for managing the SVG `stroke` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `stroke` attribute on SVG elements, following the SVG 2
+ * specification for painting and stroking graphical content.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of the stroke property,
+ * ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in SVG tag and component classes.
+ * - Enforces standards-compliant handling of the SVG `stroke` attribute.
+ * - Immutable method for setting or overriding the `stroke` attribute.
+ * - Supports string and `null` for flexible stroke assignment (color, pattern, or none).
+ *
+ * @link https://svgwg.org/svg2-draft/painting.html#StrokeProperty
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasStroke
+{
+    /**
+     * Sets the SVG `stroke` attribute for the element.
+     *
+     * Creates a new instance with the specified stroke value, supporting explicit assignment according to the SVG
+     * specification for painting outlines of shapes and text content elements.
+     *
+     * @param string|null $value Stroke paint value to set for the element. Accepts any valid SVG paint specification
+     * (for example, color keyword, hex, rgb(), url reference, or `null` to unset).
+     *
+     * @return static New instance with the updated `stroke` attribute.
+     *
+     * @link https://svgwg.org/svg2-draft/painting.html#StrokeProperty
+     *
+     * Usage example:
+     * ```php
+     * // sets the `stroke` attribute to 'black'
+     * $element->stroke('black');
+     *
+     * // sets the `stroke` attribute to a gradient reference
+     * $element->stroke('url(#gradient1)');
+     *
+     * // unsets the `stroke` attribute
+     * $element->stroke(null);
+     * ```
+     */
+    public function stroke(string|null $value): static
+    {
+        return $this->addAttribute(SvgProperty::STROKE, $value);
+    }
+}

--- a/src/Base/BaseSvg.php
+++ b/src/Base/BaseSvg.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\Media\{HasHeight, HasWidth};
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Helper\{Attributes, Enum};
-use UIAwesome\Html\Svg\Attribute\HasFill;
+use UIAwesome\Html\Svg\Attribute\{HasFill, HasStroke};
 use UIAwesome\Html\Svg\Exception\Message;
 use UIAwesome\Html\Svg\Values\SvgProperty;
 
@@ -51,6 +51,7 @@ abstract class BaseSvg extends BaseBlock implements Stringable
 {
     use HasFill;
     use HasHeight;
+    use HasStroke;
     use HasWidth;
 
     /**
@@ -168,28 +169,6 @@ abstract class BaseSvg extends BaseBlock implements Stringable
     public function preserveAspectRatio(string|null $value): static
     {
         return $this->addAttribute(SvgProperty::PRESERVE_ASPECT_RATIO, $value);
-    }
-
-    /**
-     * Sets the `stroke` attribute for the SVG element.
-     *
-     * Creates a new instance with the specified stroke value, supporting explicit assignment according to the HTML
-     * specification for SVG attributes.
-     *
-     * @param string|null $value Stroke color or pattern.
-     *
-     * @return static New instance with the updated `stroke` attribute.
-     *
-     * @link https://svgwg.org/svg2-draft/painting.html#StrokeProperty
-     *
-     * Usage example:
-     * ```php
-     * Svg::tag()->stroke('black');
-     * ```
-     */
-    public function stroke(string|null $value): static
-    {
-        return $this->addAttribute(SvgProperty::STROKE, $value);
     }
 
     /**

--- a/tests/Attribute/HasStrokeTest.php
+++ b/tests/Attribute/HasStrokeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Attribute;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Svg\Attribute\HasStroke;
+use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\StrokeProvider;
+
+/**
+ * Test suite for {@see HasStroke} trait functionality and behavior.
+ *
+ * Validates the management of the SVG `stroke` attribute according to the SVG 2 specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `stroke` attribute in tag rendering, supporting both
+ * string and `null` for dynamic identifier assignment.
+ *
+ * Test coverage.
+ * - Accurate rendering of attributes with the `stroke` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of the trait's API when setting or overriding the `stroke` attribute.
+ * - Proper assignment and overriding of `stroke` value.
+ *
+ * {@see StrokeProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasStrokeTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(StrokeProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithStrokeAttribute(
+        string|null $stroke,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasStroke;
+        };
+
+        $instance = $instance->attributes($attributes)->stroke($stroke);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenStrokeAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasStroke;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingStrokeAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasStroke;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->stroke(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(StrokeProvider::class, 'values')]
+    public function testSetStrokeAttributeValue(
+        string|null $stroke,
+        array $attributes,
+        string|null $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasStroke;
+        };
+
+        $instance = $instance->attributes($attributes)->stroke($stroke);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['stroke'] ?? '',
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Attribute/StrokeProvider.php
+++ b/tests/Support/Provider/Attribute/StrokeProvider.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Svg\Tests\Attribute\HasStrokeTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the SVG `stroke` attribute in tag rendering, ensuring
+ * standards-compliant assignment, override behavior, and value propagation according to the SVG specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and unsetting the `stroke` attribute, supporting
+ * both explicit string and `null` for attribute removal, to maintain consistent output across different rendering
+ * configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, override, and removal of the `stroke` attribute in SVG element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of empty string, `null`, and standard string for the `stroke` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class StrokeProvider
+{
+    /**
+     * Provides test cases for SVG `stroke` attribute rendering scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the SVG `stroke` attribute, including
+     * empty string, `null`, and standard string.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for `stroke` attribute rendering scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'red',
+                ['stroke' => 'blue'],
+                ' stroke="red"',
+                "Should return new 'stroke' after replacing the existing 'stroke' attribute.",
+            ],
+            'string color' => [
+                'red',
+                [],
+                ' stroke="red"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string gradient' => [
+                'url(#gradient1)',
+                [],
+                ' stroke="url(#gradient1)"',
+                'Should return the attribute value after setting it to a gradient reference.',
+            ],
+            'unset with null' => [
+                null,
+                ['stroke' => 'red'],
+                '',
+                "Should unset the 'stroke' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for SVG `stroke` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the SVG `stroke` attribute, including
+     * empty string, `null`, and standard string.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `stroke` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'red',
+                ['stroke' => 'blue'],
+                'red',
+                "Should return new 'stroke' after replacing the existing 'stroke' attribute.",
+            ],
+            'string color' => [
+                'red',
+                [],
+                'red',
+                'Should return the attribute value after setting it.',
+            ],
+            'string gradient' => [
+                'url(#gradient1)',
+                [],
+                'url(#gradient1)',
+                'Should return the attribute value after setting it to a gradient reference.',
+            ],
+            'unset with null' => [
+                null,
+                ['stroke' => 'red'],
+                '',
+                "Should unset the 'stroke' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated stroke attribute support for SVG elements, enabling users to set, update, or unset stroke values with a consistent, immutable API for improved SVG styling and rendering flexibility.

* **Tests**
  * Introduced comprehensive test suite for stroke attribute functionality, covering attribute rendering, API immutability, and value assignment scenarios to ensure quality and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->