### PR TITLE
fix(docs): Add references to predefined enum values in `HasStrokeLineCap` and `HasStrokeLineJoin` traits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enh #14: Add `HasStrokeLineJoin` trait and corresponding tests for managing SVG `stroke-linejoin` attribute (@terabytesoftw)
 - Enh #15: Add `HasStrokeWidth` trait and corresponding tests for managing SVG `stroke-width` attribute (@terabytesoftw)
 - Bug #16: Update links and references to SVG 2 specification across multiple attributes and tests (@terabytesoftw)
+- Bug #17: Add references to predefined enum values in `HasStrokeLineCap` and `HasStrokeLineJoin` traits (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasStrokeLineCap.php
+++ b/src/Attribute/HasStrokeLineCap.php
@@ -42,6 +42,7 @@ trait HasStrokeLineCap
      * @return static New instance with the updated `stroke-linecap` attribute.
      *
      * @link https://svgwg.org/svg2-draft/painting.html#LineCaps
+     * {@see StrokeLineCap} for predefined enum values.
      *
      * Usage example:
      * ```php

--- a/src/Attribute/HasStrokeLineJoin.php
+++ b/src/Attribute/HasStrokeLineJoin.php
@@ -43,6 +43,7 @@ trait HasStrokeLineJoin
      * @return static New instance with the updated `stroke-linejoin` attribute.
      *
      * @link https://svgwg.org/svg2-draft/painting.html#LineJoin
+     * {@see StrokeLineJoin} for predefined enum values.
      *
      * Usage example:
      * ```php


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with improved references to predefined attribute values for stroke configuration, making available options more discoverable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->