### PR TITLE
feat(svg): Add `G` class and corresponding tests for SVG `<g>` element functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Enh #21: Add `HasOpacity` trait and corresponding tests for managing SVG `opacity` attribute (@terabytesoftw)
 - Bug #22: Add float type support to `stroke-dasharray` attribute and update documentation (@terabytesoftw)
 - Enh #23: Add `HasTransform` trait and corresponding tests for managing SVG `transform` attribute (@terabytesoftw)
+- Enh #24: Add `G` class and corresponding tests for SVG `<g>` element functionality (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/G.php
+++ b/src/G.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg;
+
+use UIAwesome\Html\Core\Tag\BlockInterface;
+use UIAwesome\Html\Svg\Attribute\{
+    HasFill,
+    HasOpacity,
+    HasStroke,
+    HasStrokeDashArray,
+    HasStrokeLineCap,
+    HasStrokeLineJoin,
+    HasStrokeWidth,
+    HasTransform,
+};
+use UIAwesome\Html\Svg\Tag\SvgBlock;
+
+/**
+ * Represents the SVG `<g>` (group) element for grouping and transforming SVG content.
+ *
+ * Provides a standards-compliant, immutable API for rendering the `<g>` container element, following the SVG 2 and HTML
+ * specifications for grouping, inheriting attributes, and applying transformations to child elements.
+ *
+ * The `<g>` element is used to group SVG shapes and other elements, allowing collective transformations, attribute
+ * inheritance, and referencing via the `<use>` element. Attributes set on `<g>` are inherited by its children, and any
+ * transformation applied to the group affects all contained elements.
+ *
+ * Key features:
+ * - Designed for use in SVG tag/component classes requiring logical grouping of elements.
+ * - Standards-compliant implementation of the SVG `<g>` container element.
+ * - Supports grouping, attribute inheritance, and collective transformations.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class G extends Base\BaseSvgTag
+{
+    use HasFill;
+    use HasOpacity;
+    use HasStroke;
+    use HasStrokeDashArray;
+    use HasStrokeLineCap;
+    use HasStrokeLineJoin;
+    use HasStrokeWidth;
+    use HasTransform;
+
+    /**
+     * Returns the tag enumeration for the `g` element.
+     *
+     * @return BlockInterface Tag enumeration instance for `<g>`.
+     *
+     * {@see SvgBlock} for valid SVG block-level tags.
+     */
+    protected function getTag(): BlockInterface
+    {
+        return SvgBlock::G;
+    }
+}

--- a/src/Tag/SvgBlock.php
+++ b/src/Tag/SvgBlock.php
@@ -33,6 +33,13 @@ enum SvgBlock: string implements BlockInterface
     case DEFS = 'defs';
 
     /**
+     * `<g>` - Groups SVG shapes together.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+     */
+    case G = 'g';
+
+    /**
      * `<svg>` - The root container for SVG graphics.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg

--- a/tests/GTest.php
+++ b/tests/GTest.php
@@ -1,0 +1,462 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests;
+
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Core\Values\{Aria, DataProperty, Language, Role};
+use UIAwesome\Html\Svg\G;
+use UIAwesome\Html\Svg\Tests\Support\Stub\DefaultProvider;
+use UIAwesome\Html\Svg\Tests\Support\TestSupport;
+use UIAwesome\Html\Svg\Values\{StrokeLineCap, StrokeLineJoin};
+
+/**
+ * Test suite for {@see G} element functionality and behavior.
+ *
+ * Validates the management and rendering of the SVG `<g>` element according to the SVG and HTML Living Standard
+ * specifications.
+ *
+ * Ensures correct handling, immutability, and validation of the `<g>` tag rendering, supporting all global HTML and SVG
+ * attributes, content, and provider-based configuration.
+ *
+ * Test coverage:
+ * - Accurate rendering of the `<g>` element with inline content.
+ * - Correct application of global HTML attributes and SVG-specific attributes like `fill`, and `transform`.
+ * - Error handling for invalid attributes or configuration.
+ * - Immutability of the API, ensuring that setting attributes returns a new instance.
+ * - Integration with configuration providers and global factory defaults.
+ * - Nested rendering structure using `begin()` and `end()` methods.
+ * - Precedence of user-defined attributes over global defaults and provider settings.
+ *
+ * {@see G} for element implementation details.
+ * {@see SimpleFactory} for default configuration management.
+ * {@see TestSupport} for assertion utilities.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class GTest extends TestCase
+{
+    use TestSupport;
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g aria-pressed="true">
+            value
+            </g>
+            HTML,
+            G::tag()->addAriaAttribute('pressed', true)->content('value')->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g aria-pressed="true">
+            value
+            </g>
+            HTML,
+            G::tag()->addAriaAttribute(Aria::PRESSED, true)->content('value')->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g data-value="value">
+            value
+            </g>
+            HTML,
+            G::tag()->addDataAttribute('value', 'value')->content('value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g data-value="value">
+            value
+            </g>
+            HTML,
+            G::tag()->addDataAttribute(DataProperty::VALUE, 'value')->content('value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g aria-controls="modal-1" aria-hidden="false" aria-label="Close">
+            value
+            </g>
+            HTML,
+            G::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => static fn(): string => 'modal-1',
+                        'hidden' => false,
+                        'label' => 'Close',
+                    ],
+                )
+                ->content('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g class="value">
+            value
+            </g>
+            HTML,
+            G::tag()->attributes(['class' => 'value'])->content('value')->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g>
+            Content
+            </g>
+            HTML,
+            G::tag()->content('value')->begin() . 'Content' . G::end(),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g class="value">
+            value
+            </g>
+            HTML,
+            G::tag()->class('value')->content('value')->render(),
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g>
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g data-value="test-value">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->dataAttributes(['value' => 'test-value'])->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g class="default-class">
+            value
+            </g>
+            HTML,
+            G::tag(['class' => 'default-class'])->content('value')->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g class="default-class">
+            value
+            </g>
+            HTML,
+            G::tag()->addDefaultProvider(DefaultProvider::class)->content('value')->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithFill(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g fill="#ff0000">
+            value
+            </g>
+            HTML,
+            G::tag()->fill('#ff0000')->content('value')->render(),
+            "Failed asserting that element renders correctly with 'fill' attribute.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(G::class, ['class' => 'default-class']);
+
+        self::equalsWithoutLE(
+            <<<HTML
+            <g class="default-class">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(G::class, []);
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g id="test-id">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->id('test-id')->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g lang="es">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->lang(Language::SPANISH)->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithOpacity(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g opacity="0.5">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->opacity('0.5')->render(),
+            "Failed asserting that element renders correctly with 'opacity' attribute.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g role="banner">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->role('banner')->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g role="banner">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->role(Role::BANNER)->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithStroke(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke="#00ff00">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->stroke('#00ff00')->render(),
+            "Failed asserting that element renders correctly with 'stroke' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeDashArray(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-dasharray="5,5">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeDashArray('5,5')->render(),
+            "Failed asserting that element renders correctly with 'stroke-dasharray' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeLineCap(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-linecap="round">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeLineCap('round')->render(),
+            "Failed asserting that element renders correctly with 'stroke-linecap' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeLineCapUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-linecap="square">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeLineCap(StrokeLineCap::SQUARE)->render(),
+            "Failed asserting that element renders correctly with 'stroke-linecap' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeLineJoin(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-linejoin="round">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeLineJoin('round')->render(),
+            "Failed asserting that element renders correctly with 'stroke-linejoin' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeLineJoinUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-linejoin="round">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeLineJoin(StrokeLineJoin::ROUND)->render(),
+            "Failed asserting that element renders correctly with 'stroke-linejoin' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeWidth(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-width="2">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeWidth('2')->render(),
+            "Failed asserting that element renders correctly with 'stroke-width' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g style='test-value'>
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->style('test-value')->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g tabindex="3">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->tabIndex(3)->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g>
+            value
+            </g>
+            HTML,
+            (string) G::tag()->content('value'),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTransform(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g transform="rotate(45)">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->transform('rotate(45)')->render(),
+            "Failed asserting that element renders correctly with 'transform' attribute.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(G::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        self::equalsWithoutLE(
+            <<<HTML
+            <g class="from-global" id="id-user">
+            value
+            </g>
+            HTML,
+            G::tag(['id' => 'id-user'])->content('value')->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(G::class, []);
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SVG group elements with styling and transformation capabilities.

* **Tests**
  * Added comprehensive test coverage for the new SVG group element functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->