### PR TITLE
fix(test): Add tests for rendering SVG with `stroke-dasharray`, `stroke-linecap`, and `stroke-linejoin` attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bug #22: Add float type support to `stroke-dasharray` attribute and update documentation (@terabytesoftw)
 - Enh #23: Add `HasTransform` trait and corresponding tests for managing SVG `transform` attribute (@terabytesoftw)
 - Enh #24: Add `G` class and corresponding tests for SVG `<g>` element functionality (@terabytesoftw)
+- Bug #25: Add tests for rendering SVG with `stroke-dasharray`, `stroke-linecap`, and `stroke-linejoin` attributes (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -13,6 +13,7 @@ use UIAwesome\Html\Svg\Exception\Message;
 use UIAwesome\Html\Svg\Svg;
 use UIAwesome\Html\Svg\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
 use UIAwesome\Html\Svg\Tests\Support\TestSupport;
+use UIAwesome\Html\Svg\Values\{StrokeLineCap, StrokeLineJoin};
 
 /**
  * Test suite for {@see Svg} element functionality and behavior.
@@ -618,6 +619,19 @@ final class SvgTest extends TestCase
         );
     }
 
+    public function testRenderWithStrokeDashArray(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <svg stroke-dasharray="5,5">
+            value
+            </svg>
+            HTML,
+            Svg::tag()->content('value')->strokeDashArray('5,5')->render(),
+            "Failed asserting that element renders correctly with 'stroke-dasharray' attribute.",
+        );
+    }
+
     public function testRenderWithStrokeLineCap(): void
     {
         self::equalsWithoutLE(
@@ -631,6 +645,19 @@ final class SvgTest extends TestCase
         );
     }
 
+    public function testRenderWithStrokeLineCapUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <svg stroke-linecap="square">
+            value
+            </svg>
+            HTML,
+            Svg::tag()->content('value')->strokeLineCap(StrokeLineCap::SQUARE)->render(),
+            "Failed asserting that element renders correctly with 'stroke-linecap' attribute.",
+        );
+    }
+
     public function testRenderWithStrokeLineJoin(): void
     {
         self::equalsWithoutLE(
@@ -640,6 +667,19 @@ final class SvgTest extends TestCase
             </svg>
             HTML,
             Svg::tag()->content('value')->strokeLineJoin('round')->render(),
+            "Failed asserting that element renders correctly with 'stroke-linejoin' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeLineJoinUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <svg stroke-linejoin="round">
+            value
+            </svg>
+            HTML,
+            Svg::tag()->content('value')->strokeLineJoin(StrokeLineJoin::ROUND)->render(),
             "Failed asserting that element renders correctly with 'stroke-linejoin' attribute.",
         );
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                               |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for SVG stroke attributes including stroke-dasharray, stroke-linecap, and stroke-linejoin rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->