### PR TITLE
feat(attribute): Add `HasFillOpacity` trait and corresponding tests for managing SVG `fill-opacity` attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Enh #23: Add `HasTransform` trait and corresponding tests for managing SVG `transform` attribute (@terabytesoftw)
 - Enh #24: Add `G` class and corresponding tests for SVG `<g>` element functionality (@terabytesoftw)
 - Bug #25: Add tests for rendering SVG with `stroke-dasharray`, `stroke-linecap`, and `stroke-linejoin` attributes (@terabytesoftw)
+- Enh #26: Add `HasFillOpacity` trait and corresponding tests for managing SVG `fill-opacity` attribute (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasFillOpacity.php
+++ b/src/Attribute/HasFillOpacity.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Attribute;
+
+use UIAwesome\Html\Svg\Values\SvgProperty;
+
+/**
+ * Trait for managing SVG `fill-opacity` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting `fill-opacity` attribute on SVG elements, following the SVG
+ * 2 specification for painting and opacity properties.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of fill opacity property,
+ * ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in SVG tag and component classes.
+ * - Enforces standards-compliant handling of SVG `fill-opacity` attribute.
+ * - Immutable method for setting or overriding the `fill-opacity` attribute.
+ * - Supports string and `null` for flexible fill opacity assignment ('0-1' range or unset).
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fill-opacity
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFillOpacity
+{
+    /**
+     * Sets SVG `fill-opacity` attribute for the element.
+     *
+     * Creates a new instance with the specified fill opacity value, supporting explicit assignment according to the SVG
+     * 2 specification for painting and opacity properties.
+     *
+     * @param string|null $value Fill opacity value to set for the element. Accepts any valid opacity value ('0-1' range
+     * or `null` to unset).
+     *
+     * @return static New instance with the updated `fill-opacity` attribute.
+     *
+     * @link https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty
+     *
+     * Usage example:
+     * ```php
+     * // sets the `fill-opacity` attribute to '0.5'
+     * $element->fillOpacity('0.5');
+     *
+     * // unsets the `fill-opacity` attribute
+     * $element->fillOpacity(null);
+     * ```
+     */
+    public function fillOpacity(string|null $value): static
+    {
+        return $this->addAttribute(SvgProperty::FILL_OPACITY, $value);
+    }
+}

--- a/src/Base/BaseSvg.php
+++ b/src/Base/BaseSvg.php
@@ -17,6 +17,7 @@ use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Helper\{Attributes, Enum};
 use UIAwesome\Html\Svg\Attribute\{
     HasFill,
+    HasFillOpacity,
     HasOpacity,
     HasStroke,
     HasStrokeDashArray,
@@ -58,6 +59,7 @@ use function is_string;
 abstract class BaseSvg extends BaseBlock implements Stringable
 {
     use HasFill;
+    use HasFillOpacity;
     use HasHeight;
     use HasOpacity;
     use HasStroke;

--- a/src/Values/SvgProperty.php
+++ b/src/Values/SvgProperty.php
@@ -33,6 +33,16 @@ enum SvgProperty: string
     case FILL = 'fill';
 
     /**
+     * `fill-opacity` - Fill opacity attribute specifies the transparency of the fill paint.
+     *
+     * It defines the opacity level for the fill of the current element, with valid values ranging from 0.0 (fully
+     * transparent) to '1.0' (fully opaque).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fill-opacity
+     */
+    case FILL_OPACITY = 'fill-opacity';
+
+    /**
      * `height` - Displayed height of the rectangular viewport (not the height of its coordinate system).
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/height

--- a/tests/Attribute/HasFillOpacityTest.php
+++ b/tests/Attribute/HasFillOpacityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Attribute;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Svg\Attribute\HasFillOpacity;
+use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\FillOpacityProvider;
+
+/**
+ * Test suite for {@see HasFillOpacity} trait functionality and behavior.
+ *
+ * Validates management of SVG `fill-opacity` attribute according to SVG 2 specification.
+ *
+ * Ensures correct handling, immutability, and validation of `fill-opacity` attribute in tag rendering, supporting
+ * both string and `null` for dynamic identifier assignment.
+ *
+ * Test coverage.
+ * - Accurate rendering of attributes with `fill-opacity` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of trait's API when setting or overriding `fill-opacity` attribute.
+ * - Proper assignment and overriding of `fill-opacity` value.
+ *
+ * {@see FillOpacityProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasFillOpacityTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(FillOpacityProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithFillOpacityAttribute(
+        string|null $fillOpacity,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        $instance = $instance->attributes($attributes)->fillOpacity($fillOpacity);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenFillOpacityAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingFillOpacityAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->fillOpacity(''),
+            'Should return a new instance when setting attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(FillOpacityProvider::class, 'values')]
+    public function testSetFillOpacityAttributeValue(
+        string|null $fillOpacity,
+        array $attributes,
+        string|null $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        $instance = $instance->attributes($attributes)->fillOpacity($fillOpacity);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['fill-opacity'] ?? '',
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Attribute/FillOpacityProvider.php
+++ b/tests/Support/Provider/Attribute/FillOpacityProvider.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Svg\Tests\Attribute\HasFillOpacityTest} class.
+ *
+ * Supplies comprehensive test data for validating handling of SVG `fill-opacity` attribute in tag rendering, ensuring
+ * standards-compliant assignment, override behavior, and value propagation according to SVG 2 specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and unsetting `fill-opacity` attribute, supporting
+ * both explicit string and `null` for attribute removal, to maintain consistent output across different rendering
+ * configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, override, and removal of `fill-opacity` attribute in SVG element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of empty string, `null`, and standard string for `fill-opacity` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class FillOpacityProvider
+{
+    /**
+     * Provides test cases for SVG `fill-opacity` attribute rendering scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of SVG `fill-opacity` attribute, including
+     * empty string, `null`, and standard string.
+     *
+     * Each test case includes input value, initial attributes, expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for `fill-opacity` attribute rendering scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '0.5',
+                ['fill-opacity' => '0.8'],
+                ' fill-opacity="0.5"',
+                "Should return new 'fill-opacity' after replacing existing 'fill-opacity' attribute.",
+            ],
+            'decimal value' => [
+                '0.5',
+                [],
+                ' fill-opacity="0.5"',
+                'Should return the attribute value after setting it.',
+            ],
+            'full opacity' => [
+                '1',
+                [],
+                ' fill-opacity="1"',
+                'Should return the attribute value after setting it to full opacity.',
+            ],
+            'zero opacity' => [
+                '0',
+                [],
+                ' fill-opacity="0"',
+                'Should return the attribute value after setting it to zero opacity.',
+            ],
+            'unset with null' => [
+                null,
+                ['fill-opacity' => '0.5'],
+                '',
+                "Should unset the 'fill-opacity' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for SVG `fill-opacity` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of SVG `fill-opacity` attribute, including
+     * empty string, `null`, and standard string.
+     *
+     * Each test case includes input value, initial attributes, expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `fill-opacity` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '0.5',
+                ['fill-opacity' => '0.8'],
+                '0.5',
+                "Should return new 'fill-opacity' after replacing existing 'fill-opacity' attribute.",
+            ],
+            'decimal value' => [
+                '0.5',
+                [],
+                '0.5',
+                'Should return the attribute value after setting it.',
+            ],
+            'full opacity' => [
+                '1',
+                [],
+                '1',
+                'Should return the attribute value after setting it to full opacity.',
+            ],
+            'zero opacity' => [
+                '0',
+                [],
+                '0',
+                'Should return the attribute value after setting it to zero opacity.',
+            ],
+            'unset with null' => [
+                null,
+                ['fill-opacity' => '0.5'],
+                '',
+                "Should unset the 'fill-opacity' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Svg\Tests;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use UIAwesome\Html\Core\Factory\SimpleFactory;
@@ -40,6 +41,7 @@ use UIAwesome\Html\Svg\Values\{StrokeLineCap, StrokeLineJoin};
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
+#[Group('svg')]
 final class SvgTest extends TestCase
 {
     use TestSupport;
@@ -401,6 +403,19 @@ final class SvgTest extends TestCase
             HTML,
             Svg::tag()->content('value')->fill('#ff0000')->render(),
             "Failed asserting that element renders correctly with 'fill' attribute.",
+        );
+    }
+
+    public function testRenderWithFillOpacity(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <svg fill-opacity="0.7">
+            value
+            </svg>
+            HTML,
+            Svg::tag()->content('value')->fillOpacity('0.7')->render(),
+            "Failed asserting that element renders correctly with 'fill-opacity' attribute.",
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SVG elements can now control fill-opacity through a new immutable API method, allowing dynamic adjustment of element transparency levels

* **Tests**
  * Added comprehensive test coverage for fill-opacity functionality including attribute rendering, value assignment, instance immutability verification, empty state handling, and various edge case scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->