### PR TITLE
fix(attribute): Update validation for `stroke-miterlimit` to require a minimum value of `1`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Enh #29: Add `HasStrokeMiterlimit` trait and corresponding tests for managing SVG `stroke-miterlimit` attribute (@terabytesoftw)
 - Bug #30: Update expected type for attribute value parameters in multiple test cases (@terabytesoftw)
 - Enh #31: Add `HasStrokeOpacity` trait and corresponding tests for managing SVG `stroke-opacity` attribute (@terabytesoftw)
+- Bug #32: Update validation for `stroke-miterlimit` to require a minimum value of `1` (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasStrokeMiterlimit.php
+++ b/src/Attribute/HasStrokeMiterlimit.php
@@ -63,7 +63,7 @@ trait HasStrokeMiterlimit
      */
     public function strokeMiterlimit(float|int|string|null $value): static
     {
-        if ($value !== null && Validator::positiveLike($value, 0.99) === false) {
+        if ($value !== null && Validator::positiveLike($value, 1) === false) {
             throw new InvalidArgumentException(
                 Message::VALUE_MUST_BE_GTE_ONE_OR_NULL->getMessage(),
             );


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for the stroke-miterlimit attribute to require a minimum value of 1.

* **Documentation**
  * Added changelog entry documenting the stroke-miterlimit validation update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->