### PR TITLE
fix(attribute): Refactor `fill-opacity` and `opacity` handling with type validation and new tests for SVG attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Bug #30: Update expected type for attribute value parameters in multiple test cases (@terabytesoftw)
 - Enh #31: Add `HasStrokeOpacity` trait and corresponding tests for managing SVG `stroke-opacity` attribute (@terabytesoftw)
 - Bug #32: Update validation for `stroke-miterlimit` to require a minimum value of `1` (@terabytesoftw)
+- Bug #33: Refactor `fill-opacity` and `opacity` handling with type validation and new tests for SVG attributes (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasFillOpacity.php
+++ b/src/Attribute/HasFillOpacity.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Svg\Attribute;
 
+use InvalidArgumentException;
+use UIAwesome\Html\Helper\Validator;
+use UIAwesome\Html\Svg\Exception\Message;
 use UIAwesome\Html\Svg\Values\SvgProperty;
 
 /**
@@ -19,7 +22,7 @@ use UIAwesome\Html\Svg\Values\SvgProperty;
  * - Designed for use in SVG tag and component classes.
  * - Enforces standards-compliant handling of SVG `fill-opacity` attribute.
  * - Immutable method for setting or overriding the `fill-opacity` attribute.
- * - Supports string and `null` for flexible fill opacity assignment ('0-1' range or unset).
+ * - Supports float, int, string and `null` for flexible fill opacity assignment ('0-1' range or unset).
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing attributes.
@@ -37,8 +40,8 @@ trait HasFillOpacity
      * Creates a new instance with the specified fill opacity value, supporting explicit assignment according to the SVG
      * 2 specification for painting and opacity properties.
      *
-     * @param string|null $value Fill opacity value to set for the element. Accepts any valid opacity value ('0-1' range
-     * or `null` to unset).
+     * @param float|int|string|null $value Fill opacity value to set for the element. Accepts any valid opacity value
+     * ('0-1' range or `null` to unset).
      *
      * @return static New instance with the updated `fill-opacity` attribute.
      *
@@ -53,8 +56,14 @@ trait HasFillOpacity
      * $element->fillOpacity(null);
      * ```
      */
-    public function fillOpacity(string|null $value): static
+    public function fillOpacity(float|int|string|null $value): static
     {
+        if ($value !== null && Validator::positiveLike($value, 0, 1) === false) {
+            throw new InvalidArgumentException(
+                Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+            );
+        }
+
         return $this->addAttribute(SvgProperty::FILL_OPACITY, $value);
     }
 }

--- a/src/Attribute/HasOpacity.php
+++ b/src/Attribute/HasOpacity.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Svg\Attribute;
 
+use InvalidArgumentException;
+use UIAwesome\Html\Helper\Validator;
+use UIAwesome\Html\Svg\Exception\Message;
 use UIAwesome\Html\Svg\Values\SvgProperty;
 
 /**
@@ -19,7 +22,7 @@ use UIAwesome\Html\Svg\Values\SvgProperty;
  * - Designed for use in SVG tag and component classes.
  * - Enforces standards-compliant handling of the SVG `opacity` attribute.
  * - Immutable method for setting or overriding the `opacity` attribute.
- * - Supports `float`, `int`, `string`, and `null` for flexible opacity assignment (object or group opacity, or unset).
+ * - Supports float, int, string, and `null` for flexible opacity assignment (object or group opacity, or unset).
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing attributes.
@@ -39,7 +42,7 @@ trait HasOpacity
      * to the canvas.
      *
      * @param float|int|string|null $value Opacity value to set for the element. Accepts any valid SVG opacity value
-     * (for example, `0.0`–`1.0`, integer, string, or `null` to unset).
+     * (for example, `0.0`–`1.0`, float, integer, string, or `null` to unset).
      *
      * @return static New instance with the updated `opacity` attribute.
      *
@@ -59,6 +62,12 @@ trait HasOpacity
      */
     public function opacity(float|int|string|null $value): static
     {
+        if ($value !== null && Validator::positiveLike($value, 0, 1) === false) {
+            throw new InvalidArgumentException(
+                Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+            );
+        }
+
         return $this->addAttribute(SvgProperty::OPACITY, $value);
     }
 }

--- a/src/Base/BaseSvg.php
+++ b/src/Base/BaseSvg.php
@@ -24,6 +24,8 @@ use UIAwesome\Html\Svg\Attribute\{
     HasStrokeDashArray,
     HasStrokeLineCap,
     HasStrokeLineJoin,
+    HasStrokeMiterlimit,
+    HasStrokeOpacity,
     HasStrokeWidth,
     HasTransform,
 };
@@ -69,6 +71,8 @@ abstract class BaseSvg extends BaseBlock implements Stringable
     use HasStrokeDashArray;
     use HasStrokeLineCap;
     use HasStrokeLineJoin;
+    use HasStrokeMiterlimit;
+    use HasStrokeOpacity;
     use HasStrokeWidth;
     use HasTransform;
     use HasWidth;

--- a/tests/Attribute/HasFillOpacityTest.php
+++ b/tests/Attribute/HasFillOpacityTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Svg\Tests\Attribute;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Svg\Attribute\HasFillOpacity;
+use UIAwesome\Html\Svg\Exception\Message;
 use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\FillOpacityProvider;
 
 /**
@@ -17,7 +19,7 @@ use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\FillOpacityProvider;
  * Validates management of SVG `fill-opacity` attribute according to SVG 2 specification.
  *
  * Ensures correct handling, immutability, and validation of `fill-opacity` attribute in tag rendering, supporting
- * both string and `null` for dynamic identifier assignment.
+ * float, int, string and `null` for dynamic identifier assignment.
  *
  * Test coverage.
  * - Accurate rendering of attributes with `fill-opacity` attribute.
@@ -38,7 +40,7 @@ final class HasFillOpacityTest extends TestCase
      */
     #[DataProviderExternal(FillOpacityProvider::class, 'renderAttribute')]
     public function testRenderAttributesWithFillOpacityAttribute(
-        string|null $fillOpacity,
+        float|int|string|null $fillOpacity,
         array $attributes,
         string $expected,
         string $message,
@@ -79,7 +81,7 @@ final class HasFillOpacityTest extends TestCase
 
         self::assertNotSame(
             $instance,
-            $instance->fillOpacity(''),
+            $instance->fillOpacity('0'),
             'Should return a new instance when setting attribute, ensuring immutability.',
         );
     }
@@ -89,9 +91,9 @@ final class HasFillOpacityTest extends TestCase
      */
     #[DataProviderExternal(FillOpacityProvider::class, 'values')]
     public function testSetFillOpacityAttributeValue(
-        string|null $fillOpacity,
+        float|int|string|null $fillOpacity,
         array $attributes,
-        string $expected,
+        float|int|string $expected,
         string $message,
     ): void {
         $instance = new class {
@@ -106,5 +108,50 @@ final class HasFillOpacityTest extends TestCase
             $instance->getAttributes()['fill-opacity'] ?? '',
             $message,
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInvalidNegativeFillOpacityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+        );
+
+        $instance->fillOpacity(-5);
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInvalidOverOneFillOpacityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+        );
+
+        $instance->fillOpacity(1.5);
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInvalidStringFillOpacityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFillOpacity;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+        );
+
+        $instance->fillOpacity('invalid-value');
     }
 }

--- a/tests/Attribute/HasOpacityTest.php
+++ b/tests/Attribute/HasOpacityTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Svg\Tests\Attribute;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Svg\Attribute\HasOpacity;
+use UIAwesome\Html\Svg\Exception\Message;
 use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\OpacityProvider;
 
 /**
@@ -79,7 +81,7 @@ final class HasOpacityTest extends TestCase
 
         self::assertNotSame(
             $instance,
-            $instance->opacity(''),
+            $instance->opacity('0'),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -106,5 +108,50 @@ final class HasOpacityTest extends TestCase
             $instance->getAttributes()['opacity'] ?? '',
             $message,
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInvalidNegativeOpacityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasOpacity;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+        );
+
+        $instance->opacity(-5);
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInvalidOverOneOpacityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasOpacity;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+        );
+
+        $instance->opacity(1.5);
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInvalidStringOpacityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasOpacity;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_OUT_OF_RANGE_OR_NULL->getMessage(0, 1),
+        );
+
+        $instance->opacity('invalid-value');
     }
 }

--- a/tests/Support/Provider/Attribute/FillOpacityProvider.php
+++ b/tests/Support/Provider/Attribute/FillOpacityProvider.php
@@ -11,7 +11,7 @@ namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
  * standards-compliant assignment, override behavior, and value propagation according to SVG 2 specification.
  *
  * The test data covers real-world scenarios for setting, overriding, and unsetting `fill-opacity` attribute, supporting
- * both explicit string and `null` for attribute removal, to maintain consistent output across different rendering
+ * float, int, string, and `null` for attribute removal, to maintain consistent output across different rendering
  * configurations.
  *
  * The provider organizes test cases with descriptive names for clear identification of failure cases during test
@@ -20,7 +20,7 @@ namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
  * Key features.
  * - Ensures correct propagation, override, and removal of `fill-opacity` attribute in SVG element rendering.
  * - Named test data sets for precise failure identification.
- * - Validation of empty string, `null`, and standard string for `fill-opacity` attribute.
+ * - Validation of float, int, `null`, and standard string for `fill-opacity` attribute.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -31,23 +31,29 @@ final class FillOpacityProvider
      * Provides test cases for SVG `fill-opacity` attribute rendering scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of SVG `fill-opacity` attribute, including
-     * empty string, `null`, and standard string.
+     * float, int, string, and `null`.
      *
-     * Each test case includes input value, initial attributes, expected rendered output, and an assertion
-     * message for clear identification.
+     * Each test case includes input value, initial attributes, expected rendered output, and an assertion message for
+     * clear identification.
      *
      * @return array Test data for `fill-opacity` attribute rendering scenarios.
      *
-     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     * @phpstan-return array<string, array{float|int|string|null, mixed[], string, string}>
      */
     public static function renderAttribute(): array
     {
         return [
-            'empty string' => [
-                '',
+            'float' => [
+                0.5,
                 [],
-                '',
-                'Should return an empty string when setting an empty string.',
+                ' fill-opacity="0.5"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                0,
+                [],
+                ' fill-opacity="0"',
+                'Should return the attribute value after setting it.',
             ],
             'null' => [
                 null,
@@ -61,23 +67,17 @@ final class FillOpacityProvider
                 ' fill-opacity="0.5"',
                 "Should return new 'fill-opacity' after replacing existing 'fill-opacity' attribute.",
             ],
-            'decimal value' => [
+            'string' => [
+                '0',
+                [],
+                ' fill-opacity="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string float' => [
                 '0.5',
                 [],
                 ' fill-opacity="0.5"',
                 'Should return the attribute value after setting it.',
-            ],
-            'full opacity' => [
-                '1',
-                [],
-                ' fill-opacity="1"',
-                'Should return the attribute value after setting it to full opacity.',
-            ],
-            'zero opacity' => [
-                '0',
-                [],
-                ' fill-opacity="0"',
-                'Should return the attribute value after setting it to zero opacity.',
             ],
             'unset with null' => [
                 null,
@@ -92,23 +92,29 @@ final class FillOpacityProvider
      * Provides test cases for SVG `fill-opacity` attribute scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of SVG `fill-opacity` attribute, including
-     * empty string, `null`, and standard string.
+     * float, int, string, and `null`.
      *
      * Each test case includes input value, initial attributes, expected value, and an assertion message for
      * clear identification.
      *
      * @return array Test data for `fill-opacity` attribute scenarios.
      *
-     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     * @phpstan-return array<string, array{float|int|string|null, mixed[], float|int|string, string}>
      */
     public static function values(): array
     {
         return [
-            'empty string' => [
-                '',
+            'float' => [
+                0.5,
                 [],
-                '',
-                'Should return an empty string when setting an empty string.',
+                0.5,
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                0,
+                [],
+                0,
+                'Should return the attribute value after setting it.',
             ],
             'null' => [
                 null,
@@ -122,23 +128,17 @@ final class FillOpacityProvider
                 '0.5',
                 "Should return new 'fill-opacity' after replacing existing 'fill-opacity' attribute.",
             ],
-            'decimal value' => [
+            'string' => [
+                '0',
+                [],
+                '0',
+                'Should return the attribute value after setting it.',
+            ],
+            'string float' => [
                 '0.5',
                 [],
                 '0.5',
                 'Should return the attribute value after setting it.',
-            ],
-            'full opacity' => [
-                '1',
-                [],
-                '1',
-                'Should return the attribute value after setting it to full opacity.',
-            ],
-            'zero opacity' => [
-                '0',
-                [],
-                '0',
-                'Should return the attribute value after setting it to zero opacity.',
             ],
             'unset with null' => [
                 null,

--- a/tests/Support/Provider/Attribute/OpacityProvider.php
+++ b/tests/Support/Provider/Attribute/OpacityProvider.php
@@ -12,8 +12,8 @@ namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
  * specification.
  *
  * The test data covers real-world scenarios for setting, overriding, and unsetting the `opacity` attribute, supporting
- * explicit float, int, string and `null` for attribute removal, to maintain consistent output across different
- * rendering configurations.
+ * float, int, string, and `null` for attribute removal, to maintain consistent output across different rendering
+ * configurations.
  *
  * The provider organizes test cases with descriptive names for clear identification of failure cases during test
  * execution and debugging sessions.
@@ -21,7 +21,7 @@ namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
  * Key features.
  * - Ensures correct propagation, override, and removal of the `opacity` attribute in SVG element rendering.
  * - Named test data sets for precise failure identification.
- * - Validation of empty string, float, int, `null`, and standard string for the `opacity` attribute.
+ * - Validation of float, int, `null`, and standard string for the `opacity` attribute.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -32,7 +32,7 @@ final class OpacityProvider
      * Provides test cases for SVG `opacity` attribute rendering scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of the SVG `opacity` attribute, including
-     * empty string, float, int, `null`, and standard string.
+     * float, int, string, and `null`.
      *
      * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
      * message for clear identification.
@@ -44,22 +44,16 @@ final class OpacityProvider
     public static function renderAttribute(): array
     {
         return [
-            'empty string' => [
-                '',
-                [],
-                '',
-                'Should return an empty string when setting an empty string.',
-            ],
-            'int' => [
-                0,
-                [],
-                ' opacity="0"',
-                'Should return the attribute value after setting it.',
-            ],
             'float' => [
                 0.3,
                 [],
                 ' opacity="0.3"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                0,
+                [],
+                ' opacity="0"',
                 'Should return the attribute value after setting it.',
             ],
             'null' => [
@@ -69,15 +63,21 @@ final class OpacityProvider
                 "Should return an empty string when the attribute is set to 'null'.",
             ],
             'replace existing' => [
-                '0.5em',
+                '0.5',
                 ['opacity' => '1'],
-                ' opacity="0.5em"',
+                ' opacity="0.5"',
                 "Should return new 'opacity' after replacing the existing 'opacity' attribute.",
             ],
             'string' => [
-                '0.5em',
+                '0',
                 [],
-                ' opacity="0.5em"',
+                ' opacity="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string float' => [
+                '0.5',
+                [],
+                ' opacity="0.5"',
                 'Should return the attribute value after setting it.',
             ],
             'unset with null' => [
@@ -93,7 +93,7 @@ final class OpacityProvider
      * Provides test cases for SVG `opacity` attribute scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of the SVG `opacity` attribute, including
-     * empty string, float, int, `null`, and standard string.
+     * float, int, string, and `null`.
      *
      * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
      * clear identification.
@@ -105,22 +105,16 @@ final class OpacityProvider
     public static function values(): array
     {
         return [
-            'empty string' => [
-                '',
-                [],
-                '',
-                'Should return an empty string when setting an empty string.',
-            ],
-            'int' => [
-                0,
-                [],
-                0,
-                'Should return the attribute value after setting it.',
-            ],
             'float' => [
                 0.3,
                 [],
                 0.3,
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                0,
+                [],
+                0,
                 'Should return the attribute value after setting it.',
             ],
             'null' => [
@@ -130,15 +124,21 @@ final class OpacityProvider
                 "Should return an empty string when the attribute is set to 'null'.",
             ],
             'replace existing' => [
-                '0.5em',
+                '0.5',
                 ['opacity' => '1'],
-                '0.5em',
+                '0.5',
                 "Should return new 'opacity' after replacing the existing 'opacity' attribute.",
             ],
             'string' => [
-                '0.5em',
+                '0',
                 [],
-                '0.5em',
+                '0',
+                'Should return the attribute value after setting it.',
+            ],
+            'string float' => [
+                '0.5',
+                [],
+                '0.5',
                 'Should return the attribute value after setting it.',
             ],
             'unset with null' => [

--- a/tests/Support/Provider/Attribute/StrokeOpacityProvider.php
+++ b/tests/Support/Provider/Attribute/StrokeOpacityProvider.php
@@ -11,8 +11,8 @@ namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
  * standards-compliant assignment, override behavior, and value propagation according to SVG 2 specification.
  *
  * The test data covers real-world scenarios for setting, overriding, and unsetting `stroke-opacity` attribute,
- * supporting explicit float, int, string and `null` for attribute removal, to maintain consistent output across
- * different rendering configurations.
+ * supporting float, int, string, and `null` for attribute removal, to maintain consistent output across different
+ * rendering configurations.
  *
  * The provider organizes test cases with descriptive names for clear identification of failure cases during test
  * execution and debugging sessions.
@@ -31,7 +31,7 @@ final class StrokeOpacityProvider
      * Provides test cases for SVG `stroke-opacity` attribute rendering scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of SVG `stroke-opacity` attribute, including
-     * float, int, `null`, and standard string.
+     * float, int, string, and `null`.
      *
      * Each test case includes input value, initial attributes, expected rendered output, and an assertion message for
      * clear identification.
@@ -71,13 +71,13 @@ final class StrokeOpacityProvider
                 '0',
                 [],
                 ' stroke-opacity="0"',
-                'Should return the attribute value after setting it to zero opacity.',
+                'Should return the attribute value after setting it.',
             ],
-            'string numeric' => [
+            'string float' => [
                 '0.5',
                 [],
                 ' stroke-opacity="0.5"',
-                'Should return the attribute value after setting it to half opacity.',
+                'Should return the attribute value after setting it.',
             ],
             'unset with null' => [
                 null,
@@ -92,7 +92,7 @@ final class StrokeOpacityProvider
      * Provides test cases for SVG `stroke-opacity` attribute scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of SVG `stroke-opacity` attribute, including
-     * float, int, `null`, and standard string.
+     * float, int, string, and `null`.
      *
      * Each test case includes input value, initial attributes, expected value, and an assertion message for clear
      * identification.
@@ -114,7 +114,7 @@ final class StrokeOpacityProvider
                 1,
                 [],
                 1,
-                'Should return the attribute value after setting it to full opacity.',
+                'Should return the attribute value after setting it.',
             ],
             'null' => [
                 null,
@@ -132,13 +132,13 @@ final class StrokeOpacityProvider
                 '0',
                 [],
                 '0',
-                'Should return the attribute value after setting it to zero opacity.',
+                'Should return the attribute value after setting it.',
             ],
-            'string numeric' => [
+            'string float' => [
                 '0.5',
                 [],
                 '0.5',
-                'Should return the attribute value after setting it to half opacity.',
+                'Should return the attribute value after setting it.',
             ],
             'unset with null' => [
                 null,

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -725,6 +725,32 @@ final class SvgTest extends TestCase
         );
     }
 
+    public function testRenderWithStrokeMiterlimit(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <svg stroke-miterlimit="10">
+            value
+            </svg>
+            HTML,
+            Svg::tag()->content('value')->strokeMiterlimit(10)->render(),
+            "Failed asserting that element renders correctly with 'stroke-miterlimit' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeOpacity(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <svg stroke-opacity="0.8">
+            value
+            </svg>
+            HTML,
+            Svg::tag()->content('value')->strokeOpacity(0.8)->render(),
+            "Failed asserting that element renders correctly with 'stroke-opacity' attribute.",
+        );
+    }
+
     public function testRenderWithStrokeWidth(): void
     {
         self::equalsWithoutLE(
@@ -930,7 +956,17 @@ final class SvgTest extends TestCase
         );
         self::assertNotSame(
             $svg,
-            $svg->opacity(''),
+            $svg->fillOpacity('0'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $svg,
+            $svg->fillRule(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $svg,
+            $svg->opacity('0'),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(
@@ -945,12 +981,27 @@ final class SvgTest extends TestCase
         );
         self::assertNotSame(
             $svg,
+            $svg->strokeDashArray(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $svg,
             $svg->strokeLineCap(''),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(
             $svg,
             $svg->strokeLineJoin(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $svg,
+            $svg->strokeMiterlimit('1'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $svg,
+            $svg->strokeOpacity('0'),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `fillOpacity` as a distinct attribute separate from `opacity`
  * Added `stroke-miterlimit` and `stroke-opacity` attributes for enhanced stroke styling
  * Expanded opacity-related attributes to accept float, int, or string values

* **Bug Fixes**
  * Added validation to ensure opacity and fillOpacity values stay within the 0-1 range

* **Tests**
  * Added comprehensive validation tests for opacity attributes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->