### PR TITLE
feat(attribute): Enhance `G` element with `fill-opacity`, `fill-rule`, `stroke-miterlimit`, and `stroke-opacity` attributes, including new tests for rendering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Enh #31: Add `HasStrokeOpacity` trait and corresponding tests for managing SVG `stroke-opacity` attribute (@terabytesoftw)
 - Bug #32: Update validation for `stroke-miterlimit` to require a minimum value of `1` (@terabytesoftw)
 - Bug #33: Refactor `fill-opacity` and `opacity` handling with type validation and new tests for SVG attributes (@terabytesoftw)
+- Enh #34: Enhance `G` element with `fill-opacity`, `fill-rule`, `stroke-miterlimit`, and `stroke-opacity` attributes, including new tests for rendering (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/G.php
+++ b/src/G.php
@@ -7,11 +7,15 @@ namespace UIAwesome\Html\Svg;
 use UIAwesome\Html\Core\Tag\BlockInterface;
 use UIAwesome\Html\Svg\Attribute\{
     HasFill,
+    HasFillOpacity,
+    HasFillRule,
     HasOpacity,
     HasStroke,
     HasStrokeDashArray,
     HasStrokeLineCap,
     HasStrokeLineJoin,
+    HasStrokeMiterlimit,
+    HasStrokeOpacity,
     HasStrokeWidth,
     HasTransform,
 };
@@ -40,11 +44,15 @@ use UIAwesome\Html\Svg\Tag\SvgBlock;
 final class G extends Base\BaseSvgTag
 {
     use HasFill;
+    use HasFillOpacity;
+    use HasFillRule;
     use HasOpacity;
     use HasStroke;
     use HasStrokeDashArray;
     use HasStrokeLineCap;
     use HasStrokeLineJoin;
+    use HasStrokeMiterlimit;
+    use HasStrokeOpacity;
     use HasStrokeWidth;
     use HasTransform;
 

--- a/tests/GTest.php
+++ b/tests/GTest.php
@@ -11,7 +11,7 @@ use UIAwesome\Html\Core\Values\{Aria, DataProperty, Language, Role};
 use UIAwesome\Html\Svg\G;
 use UIAwesome\Html\Svg\Tests\Support\Stub\DefaultProvider;
 use UIAwesome\Html\Svg\Tests\Support\TestSupport;
-use UIAwesome\Html\Svg\Values\{StrokeLineCap, StrokeLineJoin};
+use UIAwesome\Html\Svg\Values\{FillRule, StrokeLineCap, StrokeLineJoin};
 
 /**
  * Test suite for {@see G} element functionality and behavior.
@@ -220,6 +220,45 @@ final class GTest extends TestCase
         );
     }
 
+    public function testRenderWithFillOpacity(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g fill-opacity="0.7">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->fillOpacity('0.7')->render(),
+            "Failed asserting that element renders correctly with 'fill-opacity' attribute.",
+        );
+    }
+
+    public function testRenderWithFillRule(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g fill-rule="evenodd">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->fillRule('evenodd')->render(),
+            "Failed asserting that element renders correctly with 'fill-rule' attribute.",
+        );
+    }
+
+    public function testRenderWithFillRuleUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g fill-rule="nonzero">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->fillRule(FillRule::NONZERO)->render(),
+            "Failed asserting that element renders correctly with 'fill-rule' attribute.",
+        );
+    }
+
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(G::class, ['class' => 'default-class']);
@@ -380,6 +419,32 @@ final class GTest extends TestCase
         );
     }
 
+    public function testRenderWithStrokeMiterlimit(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-miterlimit="10">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeMiterlimit(10)->render(),
+            "Failed asserting that element renders correctly with 'stroke-miterlimit' attribute.",
+        );
+    }
+
+    public function testRenderWithStrokeOpacity(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <g stroke-opacity="0.8">
+            value
+            </g>
+            HTML,
+            G::tag()->content('value')->strokeOpacity(0.8)->render(),
+            "Failed asserting that element renders correctly with 'stroke-opacity' attribute.",
+        );
+    }
+
     public function testRenderWithStrokeWidth(): void
     {
         self::equalsWithoutLE(
@@ -460,5 +525,71 @@ final class GTest extends TestCase
         );
 
         SimpleFactory::setDefaults(G::class, []);
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $g = G::tag();
+
+        self::assertNotSame(
+            $g,
+            $g->fill(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->fillOpacity('0'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->fillRule(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->opacity('0'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->stroke(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->strokeDashArray(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->strokeLineCap(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->strokeLineJoin(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->strokeMiterlimit('1'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->strokeOpacity('0'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->strokeWidth(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $g,
+            $g->transform(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
     }
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The G element now supports additional SVG attributes: fill-opacity, fill-rule, stroke-miterlimit, and stroke-opacity.

* **Tests**
  * Comprehensive tests added for new attributes, enum-based values, and immutability behavior across all supported attributes.

* **Documentation**
  * Changelog updated to document enhancements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->