### PR TITLE
feat(attribute): Add `HasCy` trait and corresponding tests for managing SVG `cy` attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Enh #34: Enhance `G` element with `fill-opacity`, `fill-rule`, `stroke-miterlimit`, and `stroke-opacity` attributes, including new tests for rendering (@terabytesoftw)
 - Bug #35: Refactor `G` and `Defs` class to extend `BaseSvgBlockTag` for improved SVG grouping functionality and enhance documentation (@terabytesoftw)
 - Enh #36: Add `HasCx` trait and corresponding tests for managing SVG `cx` attribute (@terabytesoftw)
+- Enh #37: Add `HasCy` trait and corresponding tests for managing SVG `cy` attribute (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasCy.php
+++ b/src/Attribute/HasCy.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Attribute;
+
+use UIAwesome\Html\Svg\Values\SvgProperty;
+
+/**
+ * Trait for managing the SVG `cy` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `cy` attribute on SVG elements, following the SVG 2
+ * specification for defining the y-axis coordinate of the center of an element.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of the center y-coordinate
+ * property, ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features:
+ * - Designed for use in SVG tag and component classes.
+ * - Enforces standards-compliant handling of the SVG `cy` attribute.
+ * - Immutable method for setting or overriding the `cy` attribute.
+ * - Supports int, float, string, and `null` for flexible coordinate assignment (absolute, relative, or unset).
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing attributes.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/cy
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCy
+{
+    /**
+     * Sets the SVG `cy` attribute for the element.
+     *
+     * Creates a new instance with the specified center y-coordinate value, supporting explicit assignment according to
+     * the SVG 2 specification for defining the vertical position of the center of an element such as a circle or
+     * ellipse.
+     *
+     * @param float|int|string|null $value Center y-coordinate value to set for the element. Accepts any valid SVG
+     * length, percentage, number, or `null` to unset (for example, '50', '10px', '50%', or `null`).
+     *
+     * @return static New instance with the updated `cy` attribute.
+     *
+     * @link https://svgwg.org/svg2-draft/geometry.html#CY
+     *
+     * Usage example:
+     * ```php
+     * // sets the `cy` attribute to 50 user units
+     * $element->cy(50);
+     *
+     * // sets the `cy` attribute to a relative value
+     * $element->cy('50%');
+     *
+     * // unsets the `cy` attribute
+     * $element->cy(null);
+     * ```
+     */
+    public function cy(float|int|string|null $value): static
+    {
+        return $this->addAttribute(SvgProperty::CY, $value);
+    }
+}

--- a/src/Values/SvgProperty.php
+++ b/src/Values/SvgProperty.php
@@ -31,6 +31,15 @@ enum SvgProperty: string
     case CX = 'cx';
 
     /**
+     * `cy` - Center y-coordinate of a circle or ellipse element.
+     *
+     * Defines the vertical position of the center point of the element in the current user coordinate system.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cy
+     */
+    case CY = 'cy';
+
+    /**
      * `fill` - Fill attribute has two different meanings.
      *
      * For shapes and text it's a presentation attribute that defines the color (or any SVG paint servers like gradients

--- a/tests/Attribute/HasCyTest.php
+++ b/tests/Attribute/HasCyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Attribute;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Svg\Attribute\HasCy;
+use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\CyProvider;
+
+/**
+ * Test suite for {@see HasCy} trait functionality and behavior.
+ *
+ * Validates the management of the SVG `cy` attribute according to the SVG 2 specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `cy` attribute in tag rendering, supporting int, float,
+ * string and `null` for dynamic coordinate assignment.
+ *
+ * Test coverage.
+ * - Accurate rendering of attributes with the `cy` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of the trait's API when setting or overriding the `cy` attribute.
+ * - Proper assignment and overriding of `cy` value.
+ *
+ * {@see CyProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasCyTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(CyProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithCyAttribute(
+        float|int|string|null $cy,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasCy;
+        };
+
+        $instance = $instance->attributes($attributes)->cy($cy);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenCyAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCy;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingCyAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCy;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->cy(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(CyProvider::class, 'values')]
+    public function testSetCyAttributeValue(
+        float|int|string|null $cy,
+        array $attributes,
+        float|int|string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasCy;
+        };
+
+        $instance = $instance->attributes($attributes)->cy($cy);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['cy'] ?? '',
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Attribute/CyProvider.php
+++ b/tests/Support/Provider/Attribute/CyProvider.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Svg\Tests\Attribute\HasCyTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the SVG `cy` attribute in tag rendering, ensuring
+ * standards-compliant assignment, override behavior, and value propagation according to the SVG 2 specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and unsetting the `cy` attribute, supporting both
+ * explicit numeric values, strings with units, and `null` for attribute removal, to maintain consistent output across
+ * different rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, override, and removal of the `cy` attribute in SVG element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of numeric, string, and `null` values for the `cy` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class CyProvider
+{
+    /**
+     * Provides test cases for SVG `cy` attribute rendering scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the SVG `cy` attribute, including numeric,
+     * string with units, and `null` values.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for `cy` attribute rendering scenarios.
+     *
+     * @phpstan-return array<string, array{float|int|string|null, mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                50.5,
+                [],
+                ' cy="50.5"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                100,
+                [],
+                ' cy="100"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                75,
+                ['cy' => 50],
+                ' cy="75"',
+                "Should return new 'cy' after replacing the existing 'cy' attribute.",
+            ],
+            'string percentage' => [
+                '50%',
+                [],
+                ' cy="50%"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with units' => [
+                '10px',
+                [],
+                ' cy="10px"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['cy' => 100],
+                '',
+                "Should unset the 'cy' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for SVG `cy` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the SVG `cy` attribute, including numeric,
+     * string with units, and `null` values.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `cy` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{float|int|string|null, mixed[], float|int|string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                50.5,
+                [],
+                50.5,
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                100,
+                [],
+                100,
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                75,
+                ['cy' => 50],
+                75,
+                "Should return new 'cy' after replacing the existing 'cy' attribute.",
+            ],
+            'string percentage' => [
+                '50%',
+                [],
+                '50%',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with units' => [
+                '10px',
+                [],
+                '10px',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['cy' => 100],
+                '',
+                "Should unset the 'cy' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the SVG `cy` attribute, enabling standardized handling of vertical coordinate values in SVG elements. Supports numeric (float, int) and string representations, including units and percentages.

* **Tests**
  * Added comprehensive test coverage for cy attribute rendering, immutability, and value assignment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->