### PR TITLE
feat(attribute): Add `HasY` trait and corresponding tests for managing SVG `y` attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Bug #40: Update validation for `fill-opacity`, `opacity`, and `stroke-opacity` attributes to use max parameter in `Validator` (@terabytesoftw)
 - Bug #41: Add additional SVG block cases and enhance test assertions for rendering attributes (@terabytesoftw)
 - Enh #42: Add `HasX` trait and corresponding tests for managing SVG `x` attribute (@terabytesoftw)
+- Enh #43: Add `HasY` trait and corresponding tests for managing SVG `y` attribute (@terabytesoftw)
 
 ## 0.2.0 March 31, 2024
 

--- a/src/Attribute/HasY.php
+++ b/src/Attribute/HasY.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Attribute;
+
+use UIAwesome\Html\Svg\Values\SvgProperty;
+
+/**
+ * Trait for managing the SVG `y` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `y` attribute on SVG elements, following the SVG 2
+ * specification for defining the y-axis coordinate of an element.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of the y-coordinate
+ * property, ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features:
+ * - Designed for use in SVG tag and component classes.
+ * - Enforces standards-compliant handling of the SVG `y` attribute.
+ * - Immutable method for setting or overriding the `y` attribute.
+ * - Supports int, string and `null` for flexible coordinate assignment (absolute, relative, or unset).
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing attributes.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/y
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasY
+{
+    /**
+     * Sets the SVG `y` attribute for the element.
+     *
+     * Creates a new instance with the specified y-coordinate value, supporting explicit assignment according to the SVG
+     * 2 specification for defining the vertical position of an element.
+     *
+     * @param int|string|null $value Y coordinate value to set for the element. Accepts any valid SVG length,
+     * percentage, or `null` to unset (for example, '50', '10px', '50%', or `null`).
+     *
+     * @return static New instance with the updated `y` attribute.
+     *
+     * @link https://svgwg.org/svg2-draft/geometry.html#YProperty
+     *
+     * Usage example:
+     * ```php
+     * // sets the `y` attribute to 20 user units
+     * $element->y(20);
+     *
+     * // sets the `y` attribute to a relative value
+     * $element->y('50%');
+     *
+     * // unsets the `y` attribute
+     * $element->y(null);
+     * ```
+     */
+    public function y(int|string|null $value): static
+    {
+        return $this->addAttribute(SvgProperty::Y, $value);
+    }
+}

--- a/tests/Attribute/HasYTest.php
+++ b/tests/Attribute/HasYTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Attribute;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Svg\Attribute\HasY;
+use UIAwesome\Html\Svg\Tests\Support\Provider\Attribute\YProvider;
+
+/**
+ * Test suite for {@see HasY} trait functionality and behavior.
+ *
+ * Validates the management of the SVG `y` attribute according to the SVG 2 specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `y` attribute in tag rendering, supporting int, string,
+ * and `null` for dynamic coordinate assignment.
+ *
+ * Test coverage.
+ * - Accurate rendering of attributes with the `y` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of the trait's API when setting or overriding the `y` attribute.
+ * - Proper assignment and overriding of `y` value.
+ *
+ * {@see YProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasYTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(YProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithYAttribute(
+        int|string|null $y,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasY;
+        };
+
+        $instance = $instance->attributes($attributes)->y($y);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenYAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasY;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingYAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasY;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->y(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(YProvider::class, 'values')]
+    public function testSetYAttributeValue(
+        int|string|null $y,
+        array $attributes,
+        int|string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasY;
+        };
+
+        $instance = $instance->attributes($attributes)->y($y);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['y'] ?? '',
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Attribute/YProvider.php
+++ b/tests/Support/Provider/Attribute/YProvider.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Svg\Tests\Support\Provider\Attribute;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Svg\Tests\Attribute\HasYTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the SVG `y` attribute in tag rendering, ensuring
+ * standards-compliant assignment, override behavior, and value propagation according to the SVG 2 specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and unsetting the `y` attribute, supporting int,
+ * string and `null` for attribute removal, to maintain consistent output across different rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, override, and removal of the `y` attribute in SVG element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of int, string and `null` values for the `y` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class YProvider
+{
+    /**
+     * Provides test cases for SVG `y` attribute rendering scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the SVG `y` attribute, including int,
+     * string and `null` values.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for `y` attribute rendering scenarios.
+     *
+     * @phpstan-return array<string, array{int|string|null, mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'integer' => [
+                10,
+                [],
+                ' y="10"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '75',
+                ['y' => '50'],
+                ' y="75"',
+                "Should return new 'y' after replacing the existing 'y' attribute.",
+            ],
+            'string' => [
+                '100',
+                [],
+                ' y="100"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string percentage' => [
+                '50%',
+                [],
+                ' y="50%"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with units' => [
+                '10px',
+                [],
+                ' y="10px"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['y' => '100'],
+                '',
+                "Should unset the 'y' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for SVG `y` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the SVG `y` attribute, including int,
+     * string, and `null` values.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `y` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{int|string|null, mixed[], int|string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'integer' => [
+                10,
+                [],
+                10,
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '75',
+                ['y' => '50'],
+                '75',
+                "Should return new 'y' after replacing the existing 'y' attribute.",
+            ],
+            'string' => [
+                '100',
+                [],
+                '100',
+                'Should return the attribute value after setting it.',
+            ],
+            'string percentage' => [
+                '50%',
+                [],
+                '50%',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with units' => [
+                '10px',
+                [],
+                '10px',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['y' => '100'],
+                '',
+                "Should unset the 'y' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the SVG y attribute, enabling vertical positioning configuration for SVG elements with flexible value types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->