### PR TITLE
feat: add bundled icon reference functionality with `Svg::icon()` and  `Svg::iconPath()` in `README.md` usage examples.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - chore: skip `HeredocIndentationFixer` in `php-forge/coding-standard` to preserve heredoc alignment in tests.
 - chore: update dependencies and configuration files.
 - feat: add `Svg::icon()` and `Svg::iconPath()` to resolve bundled icon references in the form `Collection:name`.
+- feat: add bundled icon reference functionality with `Svg::icon()` and `Svg::iconPath()` in `README.md` usage examples.
 
 ## 0.4.0 May 02, 2026
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,29 @@ echo Svg::tag()
 
 Note: If both the internal `content` and `filePath()` are empty, an exception is thrown.
 
+#### Bundled icon reference
+
+```php
+use UIAwesome\Html\Svg\Svg;
+
+// Resolves a bundled icon by reference (`Collection:name`) and renders it inline.
+echo Svg::icon('Bootstrap5:globe')
+    ->fill('currentColor')
+    ->height(32)
+    ->width(32)
+    ->render();
+```
+
+Need only the resolved file path (for example to configure another component)?
+
+```php
+use UIAwesome\Html\Svg\Svg;
+
+$component->iconFilePath(Svg::iconPath('Bootstrap5:globe'));
+```
+
+Note: References must match `Collection:name` where each segment is `[A-Za-z0-9_-]+`. Invalid formats, path separators, `..`, or references that do not resolve to a bundled SVG file throw an `InvalidArgumentException`.
+
 ## Documentation
 
 For detailed configuration options and advanced usage.


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [x] Documentation update
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
